### PR TITLE
Build improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ environment:
       secure: u86M99mB306NL1s9hug3LwNRNM6PbVLsgsJMzV4oshIgbLw4nSGMN1OPWw/6zJAm
 
 install:
-  - "python -m pip install pip>=19.0.3"
-  - "pip install setuptools>=40.8.0 wheel>=0.31.1 tox"
+  - "python -m pip install --upgrade pip"
+  - "pip install --upgrade setuptools wheel tox"
 
 build_script:
   - "python setup.py sdist bdist_wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
 
 install:
   - "python -m pip install pip>=19.0.3"
-  - "pip install setuptools>=40.8.0 wheel>=0.31.1 pydicom tox"
+  - "pip install setuptools>=40.8.0 wheel>=0.31.1 tox"
 
 build_script:
   - "python setup.py sdist bdist_wheel"

--- a/tools/deploy.ps1
+++ b/tools/deploy.ps1
@@ -1,3 +1,8 @@
+if (! $env:APPVEYOR_REPO_TAG_NAME) {
+    Write-Output "No Appveyor tag name supplied. Not deploying."
+    return
+}
+
 # Adapted from PEP 440:
 # https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
 $preReleaseRegex = "([-_\.]?(a|b|c|rc|alpha|beta|pre|preview)[-_\.]?[0-9]*)"
@@ -11,11 +16,6 @@ try {
     pip install --quiet --quiet twine
 
     $ErrorActionPreference = "Stop"
-
-    if (! $env:APPVEYOR_REPO_TAG_NAME) {
-        Write-Output "No Appveyor tag name supplied. Not deploying."
-        return
-    }
 
     $releaseName = $env:APPVEYOR_REPO_TAG_NAME
     $gitHubAuthToken = $env:GITHUB_TOKEN


### PR DESCRIPTION
Mostly fix wrinkles discovered when demonstrating deployment to @justineclin yesterday:
* stop installing pydicom in the AppVeyor install phase
* check tag in deploy, before installing twine

Also, there's a new pip, so just start installing the latest pip. And setuptools, wheel, and tox while we're at it.