### PR TITLE
Fix test failure caused by strict pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,4 +19,7 @@ exclude = '''
 filterwarnings = [
     "error",
     "ignore:SelectableGroups:DeprecationWarning",
+    "ignore:<class '.*'> is not using a cooperative constructor:pytest.PytestDeprecationWarning",
+    "ignore:The \\(fspath. py.path.local\\) argument to .* is deprecated.:pytest.PytestDeprecationWarning",
+    "ignore:.* is an Item subclass and should not be a collector.*:pytest.PytestWarning",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py37,py38,py39,py310
 [testenv]
 # install pytest in the virtualenv where commands will be executed
 deps =
-    pytest >= 6.2.4
+    pytest >= 7.0.1
     pytest-black
     pydicom>=2.1.1
     flake8


### PR DESCRIPTION
Pytest 7 not ignoring warnings as instructed on pytest.ini
pytest-dev/pytest#9643