### PR TITLE
Expect DA fields to be 8 characters

### DIFF
--- a/src/dicognito/datetimeanonymizer.py
+++ b/src/dicognito/datetimeanonymizer.py
@@ -68,7 +68,7 @@ class DateTimeAnonymizer:
         new_times = []
         for i in range(len(dates)):
             date_value = dates[i]
-            date_format = "%Y%m%d"[: len(date_value) - 2]
+            date_format = "%Y%m%d"
             old_date = datetime.datetime.strptime(date_value, date_format).date()
 
             time_value = ""

--- a/src/dicognito/release_notes.md
+++ b/src/dicognito/release_notes.md
@@ -1,3 +1,7 @@
+### Changed
+
+- Now assuming DA fields are 8 characters long ([#123](https://github.com/blairconrad/dicognito/issues/123))
+
 ## 0.13.0
 
 ### New


### PR DESCRIPTION
Previously, we'd tried to work with values of the form YYYY and
YYYYMM, thinking they were legal. They're not.
Technically this is a breaking change, but it shouldn't affect
anyone.