### PR TITLE
Pin flake8 to be < 5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ deps =
     pytest >= 7.0.1
     pytest-black
     pydicom>=2.1.1
-    flake8
+    flake8<5
     pep8-naming
     pytest-flake8
     mypy


### PR DESCRIPTION
pytest-flake8 doesn't work with flake8 5, as reported in
tholo/pytest-flake8#87.

Until that issue is fixed and we can rely on newer pytest-flake8,
pin flake8.