### PR TITLE
Run mypy as a separate check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = '''
   )/
 )
 '''
-[tool.pylama.linter.mypy]
+[tool.mypy]
 show_error_codes=true
 show_error_context=true
 show_column_numbers=true
@@ -29,21 +29,21 @@ strict_optional=true
 
 strict=true
 
-[tool.pylama]
-linters = "mccabe,mypy,pycodestyle,pyflakes"
-skip = ".tox/*"
-
-[[tool.pylama.linter.mypy.overrides]]
+[[tool.mypy.overrides]]
 module="pydicom.*"
 ignore_missing_imports = true
 
-[[tool.pylama.linter.mypy.overrides]]
+[[tool.mypy.overrides]]
 module="pytest."
 ignore_missing_imports = true
 
-[[tool.pylama.linter.mypy.overrides]]
+[[tool.mypy.overrides]]
 module="tests.*"
 allow_untyped_defs = true
+
+[tool.pylama]
+linters = "mccabe,pycodestyle,pyflakes"
+skip = ".tox/*"
 
 [tool.pylama.linter.pycodestyle]
 ignore = "E203,W503"

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,15 @@ envlist = py37,py38,py39,py310,py311
 # install pytest in the virtualenv where commands will be executed
 deps =
     black
+    mypy
     pydicom>=2.1.1 ; python_version < "3.11"
     git+https://github.com/pydicom/pydicom.git ; python_version > "3.10"
-    pylama[mccabe,mypy,pycodestyle,pyflakes,toml]
+    pylama[mccabe,pycodestyle,pyflakes,toml]
     pytest >= 7.0.1
 
 commands =
     # NOTE: you can run any command line tool here - not just tests
     black --check --diff --quiet .
     pylama src tests
+    mypy src tests
     pytest {posargs}


### PR DESCRIPTION
There were inconsistencies with how pylama called mypy, and it was
very difficult to coordinate the pyproject.toml file. Easier for now
just to run the tool standalone.