### PR TITLE
Release using a trusted publisher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+
     steps:
       - name: Reject build if release name disagrees with tag
         if: format('{0}{1}', 'refs/tags/', needs.package.outputs.release-name) != github.ref
@@ -94,7 +98,4 @@ jobs:
           prerelease: ${{ needs.package.outputs.is-prerelease }}
           draft: false
       - name: Publish distribution package to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/src/dicognito/release_notes.md
+++ b/src/dicognito/release_notes.md
@@ -1,3 +1,5 @@
+## 0.16.0a1
+
 ### Changed
 
 - Require pydicom 2.3.1 or higher ([#136](https://github.com/blairconrad/dicognito/issues/136))


### PR DESCRIPTION
Converted using steps at https://docs.pypi.org/trusted-publishers/