### PR TITLE
Fix version table separator

### DIFF
--- a/src/dicognito/_config.py
+++ b/src/dicognito/_config.py
@@ -34,7 +34,7 @@ class VersionAction(argparse.Action):
         def print_table(version_rows: Sequence[Tuple[str, str]]) -> None:
             row_format = "{:12} | {}"
             print(row_format.format("module", "version"))
-            print(row_format.format("-  -----", "-------"))
+            print(row_format.format("------", "-------"))
             for module, version in version_rows:
                 # Some version strings have multiple lines and need to be squashed
                 print(row_format.format(module, version.replace("\n", " ")))

--- a/src/dicognito/release_notes.md
+++ b/src/dicognito/release_notes.md
@@ -1,3 +1,6 @@
+### Fixed
+- Version table format has bad separator ([#147](https://github.com/blairconrad/dicognito/issues/147))
+
 ## 0.16.0a1
 
 ### Changed


### PR DESCRIPTION
It looked like 

```
module       | version
-  -----     | -------
platform     | Windows-10-10.0.22621-SP0
Python       | 3.11.3 (tags/v3.11.3:f3909b8, Apr  4 2023, 23:49:59) [MSC v.1934 64 bit (AMD64)]
dicognito    | 0.16.0a1
pydicom      | 2.3.1
```

there's 2 bonus spaces in the "------" below "module".