### PR TITLE
Replace set-output with writes to GITHUB_OUTPUT file

### DIFF
--- a/tools/gather-release-info-for-github-actions.py
+++ b/tools/gather-release-info-for-github-actions.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 with open("src/dicognito/release_notes.md") as release_notes:
@@ -18,6 +19,7 @@ with open("src/dicognito/release_notes.md") as release_notes:
 
         release_body = release_body.strip().replace("%", "%25").replace("\n", "%0A").replace("\r", "%0D")
 
-        print(f"::set-output name=release-name::{release_name}")
-        print(f"::set-output name=is-prerelease::{is_prerelease}")
-        print(f"::set-output name=release-body::{release_body}")
+        with open(os.environ["GITHUB_OUTPUT"], mode="a") as github_output:
+            print(f"release-name={release_name}", file=github_output)
+            print(f"is-prerelease={is_prerelease}", file=github_output)
+            print(f"release-body={release_body}", file=github_output)


### PR DESCRIPTION
set-output was deprecated. See
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ for more.