### PR TITLE
Support Python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
       matrix:
         job-prefix: ['']
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version:
+          - '3.10'
+          - '3.11'
         include:
           - job-prefix: 'experimental '
             os: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,12 @@ jobs:
         python-version:
           - '3.10'
           - '3.11'
-        include:
-          - job-prefix: 'experimental '
-            os: ubuntu-latest
-            python-version: '3.12-dev'
+          - '3.12'
+        # Uncomment the following lines to test with a not-yet supported Python version
+        # include:
+        #   - job-prefix: 'experimental '
+        #     os: ubuntu-latest
+        #     python-version: '3.12-dev'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,10 @@ allow_untyped_defs = true
 xfail_strict=true
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py310"
 line-length = 120
+
+[tool.ruff.lint]
 select = ["ALL"]
 
 ignore = [
@@ -51,10 +53,10 @@ ignore = [
   "W191",     # may cause conflicts when used with the formatter.
 ]
 
-[tool.ruff.flake8-annotations]
+[tool.ruff.lint.flake8-annotations]
 mypy-init-return = true
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "assets/**" = [
   "ANN001",   # not public code. No type annotations needed.
   "ANN201",   # not public code. No type annotations needed.

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,6 @@ setuptools.setup(
     packages=setuptools.find_packages("src"),
     include_package_data=True,
     classifiers=[
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
@@ -38,6 +36,6 @@ setuptools.setup(
         "Environment :: Console",
         "Intended Audience :: Healthcare Industry",
     ],
-    install_requires=["pydicom>=2.3.1"],  # sync with tox.ini
+    install_requires=["pydicom >= 2.3.1, < 3.0.0"],  # sync with tox.ini
     entry_points={"console_scripts": ["dicognito=dicognito.__main__:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setuptools.setup(
         "Environment :: Console",
         "Intended Audience :: Healthcare Industry",
     ],
-    install_requires=["pydicom >= 2.3.1, < 3.0.0"],  # sync with tox.ini
+    install_requires=["pydicom >= 3.0.1"],  # sync with tox.ini
     entry_points={"console_scripts": ["dicognito=dicognito.__main__:main"]},
 )

--- a/src/dicognito/__main__.py
+++ b/src/dicognito/__main__.py
@@ -6,7 +6,7 @@ import glob
 import logging
 import os.path
 import sys
-from typing import Iterable, Sequence
+from typing import TYPE_CHECKING
 
 import pydicom
 
@@ -16,6 +16,9 @@ from dicognito.exceptions import TagError
 from dicognito.filters import BurnedInAnnotationGuard, SaveInPlace, SaveToSOPInstanceUID, Summarize
 from dicognito.pipeline import Pipeline
 from dicognito.value_keeper import ValueKeeper
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
 
 
 def _get_filenames_from_source(source: str) -> Iterable[str]:

--- a/src/dicognito/_config.py
+++ b/src/dicognito/_config.py
@@ -2,13 +2,17 @@ from __future__ import annotations
 
 import argparse
 import sys
-from typing import Any, Sequence
+from typing import TYPE_CHECKING
 
 import pydicom
 
 import dicognito
 from dicognito.anonymizer import Anonymizer
 from dicognito.filters import BurnedInAnnotationGuard
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any
 
 
 class WhatIfAction(argparse.Action):

--- a/src/dicognito/addressanonymizer.py
+++ b/src/dicognito/addressanonymizer.py
@@ -1,5 +1,6 @@
 """Replace AD values with something that obscures the patient's identity."""
-from typing import Iterator
+
+from collections.abc import Iterator
 
 import pydicom
 
@@ -18,6 +19,7 @@ class AddressAnonymizer(ElementAnonymizer):
         ----------
         randomizer : dicognito.randomizer.Randomizer
             Provides a source of randomness.
+
         """
         self.randomizer = randomizer
 
@@ -52,6 +54,7 @@ class AddressAnonymizer(ElementAnonymizer):
         Returns
         -------
         True if the element was anonymized, or False if not.
+
         """
         value_factory = self._value_factories.get(data_element.tag, None)
         if not value_factory:

--- a/src/dicognito/anonymizer.py
+++ b/src/dicognito/anonymizer.py
@@ -1,7 +1,8 @@
 """Defines Anonymizer, the principle class used to anonymize DICOM objects."""
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterator, MutableSequence, Sequence
+from typing import TYPE_CHECKING
 
 from dicognito.addressanonymizer import AddressAnonymizer
 from dicognito.dataset_updater import DatasetUpdater, DeidentificationMethodUpdater, PatientIdentityRemovedUpdater
@@ -15,6 +16,8 @@ from dicognito.uianonymizer import UIAnonymizer
 from dicognito.unwantedelements import UnwantedElementsStripper
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator, MutableSequence, Sequence
+
     import pydicom
 
     from dicognito.element_anonymizer import ElementAnonymizer
@@ -44,6 +47,7 @@ class Anonymizer:
     >>>     with load_instance(filename) as dataset:
     >>>         anonymizer.anonymize(dataset)
     >>>         dataset.save_as("new-" + filename)
+
     """
 
     def __init__(self, id_prefix: str = "", id_suffix: str = "", seed: str | None = None) -> None:
@@ -61,6 +65,7 @@ class Anonymizer:
         seed : Optional[str]
             Seeds the data randomizer, which will produce consistent results when
             invoked with the same seed.
+
         """
         minimum_offset_hours = 62 * 24
         maximum_offset_hours = 730 * 24
@@ -129,6 +134,7 @@ class Anonymizer:
         ----------
         dataset : pydicom.dataset.Dataset
             A DICOM dataset to anonymize.
+
         """
         dataset.file_meta.walk(self._anonymize_element)
         dataset.walk(self._anonymize_element)
@@ -156,6 +162,7 @@ class Anonymizer:
         ----------
         handler : dicognito.element_anonymizer.ElementAnonymizer
             The new element handler.
+
         """
         self._element_handlers.insert(0, handler)
 

--- a/src/dicognito/dataset_updater.py
+++ b/src/dicognito/dataset_updater.py
@@ -1,9 +1,13 @@
 """Actions that contribute to anonymization of a dataset."""
+
 from __future__ import annotations
 
-from typing import Iterator
+from typing import TYPE_CHECKING
 
 import pydicom
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class DatasetUpdater:
@@ -29,6 +33,7 @@ class DeidentificationMethodUpdater(DatasetUpdater):
         ----------
         dataset : pydicom.dataset.Dataset
             The dataset to operate on.
+
         """
         if "DeidentificationMethod" not in dataset:
             dataset.DeidentificationMethod = "DICOGNITO"
@@ -63,6 +68,7 @@ class PatientIdentityRemovedUpdater(DatasetUpdater):
         ----------
         dataset : pydicom.dataset.Dataset
             The dataset to operate on.
+
         """
         if dataset.get("BurnedInAnnotation", "YES") == "NO":
             dataset.PatientIdentityRemoved = "YES"

--- a/src/dicognito/datetimeanonymizer.py
+++ b/src/dicognito/datetimeanonymizer.py
@@ -1,8 +1,8 @@
 """Replace date-based values with something that obscures the patient's identity."""
 
 import datetime
+from collections.abc import Iterator, MutableSequence
 from itertools import zip_longest
-from typing import Iterator, MutableSequence
 
 import pydicom
 
@@ -21,6 +21,7 @@ class DateTimeAnonymizer(ElementAnonymizer):
         offset_hours : int
             The number of hours to shift dates and times by. May be
             negative or zero.
+
         """
         self.offset = datetime.timedelta(hours=offset_hours)
 
@@ -41,6 +42,7 @@ class DateTimeAnonymizer(ElementAnonymizer):
         Returns
         -------
         True if an element (or two) was anonymized, or False if not.
+
         """
         if data_element.VR not in ("DA", "DT"):
             return False

--- a/src/dicognito/element_anonymizer.py
+++ b/src/dicognito/element_anonymizer.py
@@ -1,5 +1,5 @@
 """Base class for element anonymizers."""
-from typing import Iterator
+from collections.abc import Iterator
 
 from pydicom import DataElement
 from pydicom.dataset import Dataset

--- a/src/dicognito/equipmentanonymizer.py
+++ b/src/dicognito/equipmentanonymizer.py
@@ -1,5 +1,5 @@
 """Replace equipment-related values with something that obscures the patient's identity."""
-from typing import Iterator
+from collections.abc import Iterator
 
 import pydicom
 
@@ -18,6 +18,7 @@ class EquipmentAnonymizer(ElementAnonymizer):
         ----------
         address_anonymizer : dicognito.addressanonymizer.AddressAnonymizer
             Provides anonymized address components.
+
         """
         self.address_anonymizer = address_anonymizer
 
@@ -46,6 +47,7 @@ class EquipmentAnonymizer(ElementAnonymizer):
         Returns
         -------
         True if the element was anonymized, or False if not.
+
         """
         element_anonymizer = self._element_anonymizers.get(data_element.tag, None)
         if not element_anonymizer:

--- a/src/dicognito/exceptions.py
+++ b/src/dicognito/exceptions.py
@@ -12,6 +12,7 @@ class TagError(ValueError):
         ----------
         tag : str
             The malformed DICOM tag name.
+
         """
         message = f"Bad tag name '{tag}'. Must be a well-known DICOM element name or a string in the form 'stuv,wxyz' where each character is a hexadecimal digit."
         super().__init__(message)

--- a/src/dicognito/filters.py
+++ b/src/dicognito/filters.py
@@ -114,7 +114,7 @@ class SaveInPlace(Filter):
 
     def after_each(self, dataset: pydicom.dataset.Dataset) -> None:
         """Save to original filename."""
-        dataset.save_as(self.output_filename, write_like_original=False)
+        dataset.save_as(self.output_filename, enforce_file_format=True)
 
 
 class SaveToSOPInstanceUID(Filter):
@@ -132,4 +132,4 @@ class SaveToSOPInstanceUID(Filter):
     def after_each(self, dataset: pydicom.dataset.Dataset) -> None:
         """Save anonymized instance to file named by new SOP Instance UID."""
         output_filename = os.path.join(self.output_directory, dataset.SOPInstanceUID + ".dcm")
-        dataset.save_as(output_filename, write_like_original=False)
+        dataset.save_as(output_filename, enforce_file_format=True)

--- a/src/dicognito/filters.py
+++ b/src/dicognito/filters.py
@@ -1,15 +1,18 @@
 """Filters to apply before and after dataset anonymization."""
+
 from __future__ import annotations
 
 import itertools
 import logging
 import operator
 import os
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 from dicognito.pipeline import Filter
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import pydicom
 
 
@@ -68,6 +71,7 @@ class BurnedInAnnotationGuard(Filter):
         if_found : str
             What to do when an annotation is found. Can be one of
             "warn" or "fail".
+
         """
         self.assume_if = assume_if
         self.if_found = if_found
@@ -82,6 +86,7 @@ class BurnedInAnnotationGuard(Filter):
         ----------
         dataset : pydicom.dataset.Dataset
             The dataset to examine.
+
         """
         if self._should_assume_annotation(dataset):
             self._perform_annotation_action(dataset, dataset.filename)

--- a/src/dicognito/fixedvalueanonymizer.py
+++ b/src/dicognito/fixedvalueanonymizer.py
@@ -1,5 +1,5 @@
 """Replace certain values to obscure patient's identity."""
-from typing import Iterator
+from collections.abc import Iterator
 
 import pydicom
 
@@ -20,6 +20,7 @@ class FixedValueAnonymizer(ElementAnonymizer):
             elements with exactly this keyword will be changed.
         value
             The new value to assign to the element.
+
         """
         self.tag: int = pydicom.datadict.keyword_dict[keyword]
         self.value = value
@@ -45,6 +46,7 @@ class FixedValueAnonymizer(ElementAnonymizer):
         Returns
         -------
         True if the element was anonymized, or False if not.
+
         """
         if data_element.tag == self.tag:
             data_element.value = self.value

--- a/src/dicognito/idanonymizer.py
+++ b/src/dicognito/idanonymizer.py
@@ -1,5 +1,5 @@
 """Replace identifier values with something that obscures the patient's identity."""
-from typing import Iterator
+from collections.abc import Iterator
 
 import pydicom
 
@@ -29,6 +29,7 @@ class IDAnonymizer(ElementAnonymizer):
         keywords : list of str
             All of the keywords for elements to be anonymized. Only
             elements with matching keywords will be updated.
+
         """
         self.randomizer = randomizer
         self.id_prefix = id_prefix
@@ -59,6 +60,7 @@ class IDAnonymizer(ElementAnonymizer):
         Returns
         -------
         True if the element was anonymized, or False if not.
+
         """
         if data_element.tag in self.id_tags:
             self._replace_id(data_element)

--- a/src/dicognito/pnanonymizer.py
+++ b/src/dicognito/pnanonymizer.py
@@ -1,13 +1,16 @@
 """Replace PN values with something that obscures the patient's identity."""
+
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 import pydicom
 
 from dicognito.element_anonymizer import ElementAnonymizer
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from dicognito.randomizer import Randomizer
 
 
@@ -22,6 +25,7 @@ class PNAnonymizer(ElementAnonymizer):
         ----------
         randomizer : dicognito.randomizer.Randomizer
             Provides a source of randomness.
+
         """
         self.randomizer = randomizer
 
@@ -40,6 +44,7 @@ class PNAnonymizer(ElementAnonymizer):
         Returns
         -------
         True if the element was anonymized, or False if not.
+
         """
         if data_element.VR != "PN":
             return False

--- a/src/dicognito/randomizer.py
+++ b/src/dicognito/randomizer.py
@@ -1,9 +1,13 @@
 """Utilities for transforming values into hard-to-predict integers."""
+
 from __future__ import annotations
 
 import hashlib
 import os
-from typing import Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 class Randomizer:
@@ -19,6 +23,7 @@ class Randomizer:
             Used to convert input values into large integers.
             The results are completely determined by the
             given seed and the input value.
+
         """
         if seed is None:
             self.seed = str(os.urandom(20))
@@ -33,6 +38,7 @@ class Randomizer:
         ----------
         original_value
             The original value that will ultimately be replaced.
+
         """
         message = self.seed + original_value
         encoded = message.encode("utf8")
@@ -57,6 +63,7 @@ class Randomizer:
 
         suprema : sequence of int
             The upper bounds for each of the desired integer ranges.
+
         """
         big_int = self.to_int(original_value)
         result = []

--- a/src/dicognito/uianonymizer.py
+++ b/src/dicognito/uianonymizer.py
@@ -1,5 +1,5 @@
 """Replace UIs with a new value."""
-from typing import Iterator
+from collections.abc import Iterator
 
 import pydicom
 import pydicom.dataelem
@@ -40,6 +40,7 @@ class UIAnonymizer(ElementAnonymizer):
         Returns
         -------
         True if the element was anonymized, or False if not.
+
         """
         if (
             data_element.VR != "UI"

--- a/src/dicognito/unwantedelements.py
+++ b/src/dicognito/unwantedelements.py
@@ -1,5 +1,5 @@
 """Remove unwanted values from the data_element."""
-from typing import Iterator
+from collections.abc import Iterator
 
 import pydicom
 
@@ -18,6 +18,7 @@ class UnwantedElementsStripper(ElementAnonymizer):
         keywords : list of str
             All of the keywords for elements to be removed from the
             dataset.
+
         """
         self.tags = [pydicom.datadict.keyword_dict[keyword] for keyword in keywords]
 
@@ -38,6 +39,7 @@ class UnwantedElementsStripper(ElementAnonymizer):
         Returns
         -------
         True if the element was anonymized, or False if not.
+
         """
         if data_element.tag in self.tags:
             del dataset[data_element.tag]

--- a/src/dicognito/value_keeper.py
+++ b/src/dicognito/value_keeper.py
@@ -1,6 +1,6 @@
 """Retains an element's value."""
 import re
-from typing import Iterator
+from collections.abc import Iterator
 
 import pydicom
 
@@ -22,6 +22,7 @@ class ValueKeeper(ElementAnonymizer):
             Must be the well-known name of a DICOM element or must represent
             a numeric DICOM tag and be in the form "stuv,wxyz" where each
             of the characters is a hexadecimal digit.
+
         """
         self._tag: int = self._tag_from_name(tag_name)
 
@@ -46,6 +47,7 @@ class ValueKeeper(ElementAnonymizer):
         Returns
         -------
         True if the element was preserved, or False if not.
+
         """
         return data_element.tag == self._tag and True or False
 

--- a/tests/test_anonymize_single_instance.py
+++ b/tests/test_anonymize_single_instance.py
@@ -137,7 +137,7 @@ def test_other_patient_ids_anonymized_to_same_number_of_ids(number_of_ids):
         actual = dataset.OtherPatientIDs
 
         assert len(actual) == number_of_ids
-        for actual_id, original_id in zip(actual, original):
+        for actual_id, original_id in zip(actual, original, strict=False):
             assert isinstance(actual_id, str)
             assert actual_id != original_id
 

--- a/tests/test_anonymize_through_time.py
+++ b/tests/test_anonymize_through_time.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from itertools import filterfalse, tee
-from typing import Callable, Union, ValuesView
+from typing import TYPE_CHECKING
 
 import pydicom
 from dicognito.anonymizer import Anonymizer
 
 from .data_for_tests import load_minimal_instance
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, ValuesView
 
 
 def test_dataset_anonymizes_same_with_same_seed():
@@ -23,7 +26,7 @@ def test_dataset_anonymizes_same_with_same_seed():
         assert not [value.name for value in mismatches]
 
 
-_DatasetValue = Union[pydicom.DataElement, pydicom.dataelem.RawDataElement]
+_DatasetValue = pydicom.DataElement | pydicom.dataelem.RawDataElement
 
 
 def partition(

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -1,6 +1,6 @@
+from collections.abc import Iterator
 from itertools import dropwhile, islice, takewhile
 from os.path import abspath, join
-from typing import Iterator
 
 import dicognito.__main__
 import pytest

--- a/tools/release-version.py
+++ b/tools/release-version.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import sys
-from typing import Sequence
+from collections.abc import Sequence
 
 
 def main(args: Sequence[str]) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310,py311,py312
+envlist = py310,py311,py312
 
 
 [testenv]
@@ -7,7 +7,7 @@ envlist = py38,py39,py310,py311,py312
 package = wheel
 deps =
     mypy
-    pydicom >= 2.3.1 # sync with setyp.py
+    pydicom >= 2.3.1, < 3.0.0 # sync with setup.py
     pytest >= 7.0.1
     ruff == 0.1.2
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist = py310,py311,py312
 package = wheel
 deps =
     mypy
-    pydicom >= 2.3.1, < 3.0.0 # sync with setup.py
+    pydicom >= 3.0.1 # sync with setup.py
     pytest >= 7.0.1
     ruff == 0.1.2
 


### PR DESCRIPTION
To support Python 3.12, we need to upgrade the pydicom dependency to version 3 or later. This version of pydicom does not support Python 3.8 or 3.9.